### PR TITLE
[fix] added missing client sql script

### DIFF
--- a/self-administration/src/main/deploy/addon-self-administration.properties
+++ b/self-administration/src/main/deploy/addon-self-administration.properties
@@ -43,8 +43,9 @@ org.osiam.html.dependencies.bootstrap=http://getbootstrap.com/dist/css/bootstrap
 org.osiam.html.dependencies.angular=http://code.angularjs.org/1.2.0-rc.3/angular.min.js
 org.osiam.html.dependencies.jquery=http://ajax.googleapis.com/ajax/libs/jquery/2.0.3/jquery.min.js
 
-org.osiam.addon-self-administration.client.id=example-client
-org.osiam.addon-self-administration.client.secret=secret
+# Please sync the client data with the ../sql/example_data.sql
+org.osiam.addon-self-administration.client.id=addon-self-administration-client
+org.osiam.addon-self-administration.client.secret=super-secret
 org.osiam.addon-self-administration.client.scope=GET,POST,PUT,PATCH,DELETE
 
 original.org.osiam.html.form.fields=formattedName\

--- a/self-administration/src/main/sql/example_data.sql
+++ b/self-administration/src/main/sql/example_data.sql
@@ -1,0 +1,19 @@
+--
+-- Example self-administration client, please sync to the attribute values in the addon-self-administration.properties.
+-- Please update all queries in this file to your needs!
+-- Have to be imported in the database of the auth-server, before you deploy the addon-self-administration!
+--
+INSERT INTO osiam_client (internal_id, accesstokenvalidityseconds, client_secret, expiry,
+id, implicit_approval, redirect_uri, refreshtokenvalidityseconds,
+validityinseconds)
+VALUES (1, 2342, 'super-secret', null, 'addon-self-administration-client', FALSE, 'http://localhost:8080/addon-self-administration', 4684, 1337);
+
+INSERT INTO osiam_client_scopes (id, scope) VALUES (1, 'GET');
+INSERT INTO osiam_client_scopes (id, scope) VALUES (1, 'POST');
+INSERT INTO osiam_client_scopes (id, scope) VALUES (1, 'PUT');
+INSERT INTO osiam_client_scopes (id, scope) VALUES (1, 'PATCH');
+INSERT INTO osiam_client_scopes (id, scope) VALUES (1, 'DELETE');
+INSERT INTO osiam_client_grants (id, grants) VALUES (1, 'authorization_code');
+INSERT INTO osiam_client_grants (id, grants) VALUES (1, 'refresh_token');
+INSERT INTO osiam_client_grants (id, grants) VALUES (1, 'password');
+INSERT INTO osiam_client_grants (id, grants) VALUES (1, 'client_credentials');


### PR DESCRIPTION
the addon-self-administration needs also a sql script to import a client to the auth-server database before deploy this addon, right?
