### PR TITLE
Remove field `expiry` from OAuth client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 ## 1.5 - Unreleased
 
 ### Changes
+
+- remove field `expiry` from OAuth client in SQL scripts
+
+    The field `expiry` has been removed from the auth-server (osiam/auth-server#9)
+    and must be removed from the SQL scripts too.
+
 - change some attributes of OAuth client
 
     - remove unnecessary grants: authorisation code grant, refresh token grant,
@@ -31,12 +37,14 @@ information have a look at the [configuration]
 - scavenge expired tokens
 
 ### Changes
+
 - use latest plugin api release: Version 1.3.2
 - switch to latest connector release: Version 1.4
 - bump dependencies and cleanup pom
 - move documentation from wiki to repo
 
 ### Fixes
+
 - handle missing extension field gracefully
 - client database id may lead to problems with other clients
 

--- a/src/main/sql/client.sql
+++ b/src/main/sql/client.sql
@@ -4,12 +4,10 @@
 -- of the auth-server, before you deploy the addon-self-administration!
 --
 
-INSERT INTO osiam_client (internal_id, accesstokenvalidityseconds, client_secret, expiry,
-                          id, implicit_approval, redirect_uri, refreshtokenvalidityseconds,
-                          validityinseconds)
-VALUES (10, 300, 'super-secret', NULL,
-        'addon-self-administration-client', FALSE, 'http://localhost:8080/addon-self-administration', 0,
-        0);
+INSERT INTO osiam_client (internal_id, accesstokenvalidityseconds, client_secret, id,
+                          implicit_approval, redirect_uri, refreshtokenvalidityseconds, validityinseconds)
+VALUES (10, 300, 'super-secret', 'addon-self-administration-client',
+        FALSE, 'http://localhost:8080/addon-self-administration', 0, 0);
 
 INSERT INTO osiam_client_scopes (id, scope) VALUES (10, 'GET');
 INSERT INTO osiam_client_scopes (id, scope) VALUES (10, 'POST');

--- a/src/main/sql/example_data.sql
+++ b/src/main/sql/example_data.sql
@@ -2,13 +2,10 @@
 -- DEPRECATED: replaced by client.sql
 --
 
-INSERT INTO osiam_client (internal_id, accesstokenvalidityseconds, client_secret, expiry,
-                          id, implicit_approval, redirect_uri, refreshtokenvalidityseconds,
-                          validityinseconds)
-VALUES (10, 300, 'super-secret', NULL,
-        'addon-self-administration-client', FALSE, 'http://localhost:8080/addon-self-administration', 0,
-        0);
-
+INSERT INTO osiam_client (internal_id, accesstokenvalidityseconds, client_secret, id,
+                          implicit_approval, redirect_uri, refreshtokenvalidityseconds, validityinseconds)
+VALUES (10, 300, 'super-secret', 'addon-self-administration-client',
+        FALSE, 'http://localhost:8080/addon-self-administration', 0, 0);
 INSERT INTO osiam_client_scopes (id, scope) VALUES (10, 'GET');
 INSERT INTO osiam_client_scopes (id, scope) VALUES (10, 'POST');
 INSERT INTO osiam_client_scopes (id, scope) VALUES (10, 'PUT');


### PR DESCRIPTION
the field `expiry` has been removed from the auth-server (osiam/auth-server#9) and must be removed from the SQL scripts too.