### PR TITLE
Disable triggering of ITs on CircleCI after build

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -6,6 +6,7 @@ deployment:
  staging:
    branch: master
    commands:
-    - curl -X POST https://circleci.com/api/v1/project/osiam/connector4java-integration-tests/tree/master?circle-token=$CIRCLE_TOKEN
+    # de-activated as we don't build the artifacts on CircleCI, yet. Re-activate this when we do.
+    #- curl -X POST https://circleci.com/api/v1/project/osiam/connector4java-integration-tests/tree/master?circle-token=$CIRCLE_TOKEN
     - >
         curl -H "Content-Type: application/json" --data '{"source_type": "Branch", "source_name": "master"}' -X POST https://registry.hub.docker.com/u/osiamorg/osiam/trigger/${DOCKER_HUB_TRIGGER_TOKEN}/


### PR DESCRIPTION
The internal CI will do this until we build and deploy our artifacts on
CircleCI.