### PR TITLE
Remove usage of deprecated SCIMHelper class

### DIFF
--- a/src/main/java/org/osiam/addons/self_administration/controller/AccountManagementService.java
+++ b/src/main/java/org/osiam/addons/self_administration/controller/AccountManagementService.java
@@ -22,10 +22,7 @@
  */
 package org.osiam.addons.self_administration.controller;
 
-import java.util.HashMap;
-import java.util.Locale;
-import java.util.Map;
-
+import com.google.common.base.Optional;
 import org.osiam.addons.self_administration.Config;
 import org.osiam.addons.self_administration.exception.InvalidAttributeException;
 import org.osiam.addons.self_administration.template.RenderAndSendEmail;
@@ -34,7 +31,6 @@ import org.osiam.client.OsiamConnector;
 import org.osiam.client.exception.NoResultException;
 import org.osiam.client.exception.UnauthorizedException;
 import org.osiam.client.oauth.AccessToken;
-import org.osiam.resources.helper.SCIMHelper;
 import org.osiam.resources.scim.Email;
 import org.osiam.resources.scim.UpdateUser;
 import org.osiam.resources.scim.User;
@@ -46,7 +42,9 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.mail.MailException;
 import org.springframework.stereotype.Service;
 
-import com.google.common.base.Optional;
+import java.util.HashMap;
+import java.util.Locale;
+import java.util.Map;
 
 /**
  * Service class for controllers dealing with account management.
@@ -68,10 +66,8 @@ public class AccountManagementService {
     /**
      * Deactivates the account of the user with the given user ID.
      *
-     * @param userId
-     *            the ID of the user
-     * @param token
-     *            the access token
+     * @param userId the ID of the user
+     * @param token  the access token
      */
     public void deactivateUser(String userId, AccessToken token) {
         User user = osiamConnector.getUser(userId, token);
@@ -83,10 +79,8 @@ public class AccountManagementService {
     /**
      * Deletes the account of the user with the given user ID.
      *
-     * @param userId
-     *            the ID of the user
-     * @param token
-     *            the access token
+     * @param userId the ID of the user
+     * @param token  the access token
      */
     public void deleteUser(String userId, AccessToken token) {
         User user = osiamConnector.getUser(userId, token);
@@ -97,9 +91,7 @@ public class AccountManagementService {
     /**
      * Logs the given exception and returns a suitable response status.
      *
-     * @param e
-     *            the exception to handle
-     * @param {@link ResponseEntity} with the resulting error information and status code
+     * @param e the exception to handle
      */
     public ResponseEntity<String> handleException(RuntimeException e) {
         StringBuilder messageBuilder = new StringBuilder();
@@ -120,25 +112,23 @@ public class AccountManagementService {
         messageBuilder.insert(0, "{\"error\":\"");
         messageBuilder.append(e.getMessage());
         messageBuilder.append("\"}");
-        return new ResponseEntity<String>(messageBuilder.toString(), status);
+        return new ResponseEntity<>(messageBuilder.toString(), status);
     }
 
     /**
      * Sends an email informing about the account change.
      *
-     * @param user
-     *            the user
-     * @param template
-     *            the email template name
+     * @param user     the user
+     * @param template the email template name
      */
     private void sendEmail(User user, String template) {
-        Optional<Email> email = SCIMHelper.getPrimaryOrFirstEmail(user);
+        Optional<Email> email = user.getPrimaryOrFirstEmail();
         if (!email.isPresent()) {
             String message = "Unable to send email. No email of user " + user.getUserName() + " found!";
             throw new InvalidAttributeException(message, "registration.exception.noEmail");
         }
 
-        Map<String, Object> mailVariables = new HashMap<String, Object>();
+        Map<String, Object> mailVariables = new HashMap<>();
         Locale locale = SelfAdministrationHelper.getLocale(user.getLocale());
 
         renderAndSendEmailService.renderAndSendEmail(template, config.getFromAddress(), email.get().getValue(), locale,

--- a/src/main/java/org/osiam/addons/self_administration/controller/ChangeEmailController.java
+++ b/src/main/java/org/osiam/addons/self_administration/controller/ChangeEmailController.java
@@ -44,7 +44,6 @@ import org.osiam.client.exception.OsiamClientException;
 import org.osiam.client.exception.OsiamRequestException;
 import org.osiam.client.oauth.AccessToken;
 import org.osiam.client.user.BasicUser;
-import org.osiam.resources.helper.SCIMHelper;
 import org.osiam.resources.scim.Email;
 import org.osiam.resources.scim.Extension;
 import org.osiam.resources.scim.ExtensionFieldType;
@@ -163,7 +162,7 @@ public class ChangeEmailController {
     /**
      * Puts the new email an the confirmation token into the extensions of the user of the given token.
      *
-     * @param token
+     * @param token The string representation of the access token
      * @param newEmail
      * @param confirmationToken
      * @return User which has the values in his extension
@@ -239,7 +238,7 @@ public class ChangeEmailController {
             }
 
             String newEmail = extension.getField(Config.TEMP_EMAIL_FIELD, ExtensionFieldType.STRING);
-            oldEmail = SCIMHelper.getPrimaryOrFirstEmail(user);
+            oldEmail = user.getPrimaryOrFirstEmail();
 
             UpdateUser updateUser = getPreparedUserForEmailChange(extension, newEmail, oldEmail.get());
 

--- a/src/main/java/org/osiam/addons/self_administration/controller/LostPasswordController.java
+++ b/src/main/java/org/osiam/addons/self_administration/controller/LostPasswordController.java
@@ -44,7 +44,6 @@ import org.osiam.client.OsiamConnector;
 import org.osiam.client.exception.OsiamClientException;
 import org.osiam.client.exception.OsiamRequestException;
 import org.osiam.client.oauth.AccessToken;
-import org.osiam.resources.helper.SCIMHelper;
 import org.osiam.resources.scim.Email;
 import org.osiam.resources.scim.Extension;
 import org.osiam.resources.scim.UpdateUser;
@@ -122,7 +121,7 @@ public class LostPasswordController {
             return SelfAdministrationHelper.createErrorResponseEntity(e.getMessage(), HttpStatus.INTERNAL_SERVER_ERROR);
         }
 
-        Optional<Email> email = SCIMHelper.getPrimaryOrFirstEmail(updatedUser);
+        Optional<Email> email = updatedUser.getPrimaryOrFirstEmail();
         if (!email.isPresent()) {
             String message = "Could not change password. No email of user " + updatedUser.getUserName() + " found!";
             LOGGER.error(message);

--- a/src/main/java/org/osiam/addons/self_administration/registration/RegistrationService.java
+++ b/src/main/java/org/osiam/addons/self_administration/registration/RegistrationService.java
@@ -34,7 +34,6 @@ import org.osiam.addons.self_administration.plugin_api.CallbackPlugin;
 import org.osiam.addons.self_administration.service.OsiamService;
 import org.osiam.addons.self_administration.template.RenderAndSendEmail;
 import org.osiam.addons.self_administration.util.SelfAdministrationHelper;
-import org.osiam.resources.helper.SCIMHelper;
 import org.osiam.resources.scim.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
@@ -75,7 +74,7 @@ public class RegistrationService {
     }
 
     public void sendRegistrationEmail(User user, String requestUrl) {
-        Optional<Email> email = SCIMHelper.getPrimaryOrFirstEmail(user);
+        Optional<Email> email = user.getPrimaryOrFirstEmail();
         if (!email.isPresent()) {
             String message = "Could not register user. No email of user " + user.getUserName() + " found!";
             throw new InvalidAttributeException(message, "registration.exception.noEmail");

--- a/src/test/groovy/org/osiam/addons/self_administration/util/SelfAdministrationHelperSpec.groovy
+++ b/src/test/groovy/org/osiam/addons/self_administration/util/SelfAdministrationHelperSpec.groovy
@@ -23,58 +23,13 @@
 
 package org.osiam.addons.self_administration.util
 
-import com.google.common.base.Optional
 import org.joda.time.Duration
-import org.osiam.resources.helper.SCIMHelper
-import org.osiam.resources.scim.Email
-import org.osiam.resources.scim.User
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import spock.lang.Specification
 import spock.lang.Unroll
 
 class SelfAdministrationHelperSpec extends Specification {
-
-    def 'getting primary email from user'() {
-        given:
-        def thePrimaryMail = 'primary@mail.com'
-
-        Email theEmail = new Email.Builder().setPrimary(true).setValue(thePrimaryMail).build()
-        User user = new User.Builder('theMan').addEmails([theEmail] as List).build()
-
-        when:
-        Optional<Email> email = SCIMHelper.getPrimaryOrFirstEmail(user)
-
-        then:
-        email.isPresent()
-        email.get().value == thePrimaryMail
-    }
-
-    def 'should return not null if no primary email was found'() {
-        given:
-        def thePrimaryMail = 'primary@mail.com'
-
-        Email theEmail = new Email.Builder().setPrimary(false).setValue(thePrimaryMail).build()
-        User user = new User.Builder('theMan').addEmails([theEmail] as List).build()
-
-        when:
-        Optional<Email> email = SCIMHelper.getPrimaryOrFirstEmail(user)
-
-        then:
-        email.isPresent()
-        email.get().value == 'primary@mail.com'
-    }
-
-    def 'should not throw exception if users emails are not present'() {
-        given:
-        User user = new User.Builder('theMan').build()
-
-        when:
-        Optional<Email> email = SCIMHelper.getPrimaryOrFirstEmail(user)
-
-        then:
-        !email.isPresent()
-    }
 
     def 'should create a link'() {
         given:


### PR DESCRIPTION
The class `org.osiam.resources.helper.SCIMHelper` has been deprecated in osiam/scim-schema#157 this PR removes its  usage in the self-administration.