### PR TITLE
Restore support for OSIAM 2.x

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,29 +1,33 @@
 - [Database setup](#database-setup)
-- [Configuring OSIAM](#configuring-osiam)
- - [Configuration values](#configuration-values)
+- [Configuration File](#configuration-file)
+- [Connection to OSIAM](#connection-to-osiam)
+    - [OSIAM 3.x](#osiam-3x)
+        - [org.osiam.home](#orgosiamhome)
+    - [OSIAM 2.x](#osiam-2x)
+        - [org.osiam.auth-server.home](#orgosiamauth-serverhome)
+        - [org.osiam.resource-server.home](#orgosiamresource-serverhome)
+- [E-Mail](#e-mail)
     - [org.osiam.mail.from](#orgosiammailfrom)
     - [org.osiam.mail.*.linkprefix](#orgosiammaillinkprefix)
     - [org.osiam.html.*.url](#orgosiamhtmlurl)
     - [org.osiam.mail.server.*](#orgosiammailserver)
+- [Client](#client)
     - [org.osiam.addon-self-administration.client.id](#orgosiamaddon-self-administrationclientid)
     - [org.osiam.addon-self-administration.client.secret](#orgosiamaddon-self-administrationclientsecret)
-    - [org.osiam.addon-self-administration.registration.activation-token-timeout](#orgosiamaddon-self-administrationregistrationactivation-token-timeout)
-    - [org.osiam.addon-self-administration.change-email.confirmation-token-timeout](#orgosiamaddon-self-administrationchange-emailconfirmation-token-timeout)
-    - [org.osiam.addon-self-administration.lost-password.one-time-password-timeout](#orgosiamaddon-self-administrationlost-passwordone-time-password-timeout)
-    - [org.osiam.addon-self-administration.one-time-token-scavenger.enabled](#orgosiamaddon-self-administrationone-time-token-scavengerenabled)
-    - [org.osiam.html.form.usernameEqualsEmail](user-registration.md#orgosiamhtmlformusernameequalsemail)
-    - [org.osiam.html.form.password.length](user-registration.md#orgosiamhtmlformpasswordlength)
-    - [org.osiam.html.form.fields](user-registration.md#orgosiamhtmlformfields)
-    - [org.osiam.html.form.extensions](user-registration.md#orgosiamhtmlformextensions)
+- [Tokens](#tokens)
+      - [org.osiam.addon-self-administration.registration.activation-token-timeout](#orgosiamaddon-self-administrationregistrationactivation-token-timeout)
+      - [org.osiam.addon-self-administration.change-email.confirmation-token-timeout](#orgosiamaddon-self-administrationchange-emailconfirmation-token-timeout)
+      - [org.osiam.addon-self-administration.lost-password.one-time-password-timeout](#orgosiamaddon-self-administrationlost-passwordone-time-password-timeout)
+      - [org.osiam.addon-self-administration.one-time-token-scavenger.enabled](#orgosiamaddon-self-administrationone-time-token-scavengerenabled)
 
-## Database setup
-
-**PRECONDITION**
-You need to import the sql script into your postgres database which you will find in the OSIAM project!
+# Database setup
 
 For the self-administration you need to add some extension fields into the database otherwise it will not work.
 The extension is configured with it's own namespace and will not conflict user defined extensions (extension.sql).
 You need also to add a specific client for self-administration in OSIAM's database (client.sql).
+
+**Note for users of OSIAM 2.x:** the `extension.sql` must be run against the resource-server's database and the
+`client.sql` must be run against the auth-server's database.
 
 Start the database commandline:
 
@@ -39,27 +43,55 @@ and
 
 but update the client.sql before you import it and sync the data with the addon-self-administration.properties!
 
-## Configuring OSIAM
+# Configuration File
 
 This add-on needs some configuration values. Create the file
 
     /etc/osiam/addon-self-administration.properties
 
-with content based on this [example](../src/main/deploy/addon-self-administration.properties)
+with content based on this [example](../src/main/deploy/addon-self-administration.properties).
 
-### Configuration values
+# Connection to OSIAM
+
+The self administration needs to know where it can find OSIAM. This configuration depends on whether
+you use OSIAM 3.x or OSIAM 2.x.
+
+## OSIAM 3.x
+
+OSIAM 3.x now comes as a single server, so you have to configure only one endpoint.
 
 ### org.osiam.home
 
-The home location of OSIAM.
+The home location of OSIAM
 
-Default: http://localhost:8080/osiam
+Default: none
 
-#### org.osiam.mail.from
+## OSIAM 2.x
+
+OSIAM 2.x is split into auth-server and resource-server. Hence you have to configure both endpoints.
+
+### org.osiam.auth-server.home
+
+The home location of the auth server
+
+Default: http://localhost:8080/osiam-auth-server
+
+### org.osiam.resource-server.home
+
+The home location of the resource server
+
+Default: http://localhost:8080/osiam-resource-server
+
+# E-Mail
+
+The self administration sends E-Mails for certain operations, like registration. Thus a valid SMTP
+server must be configured.
+
+## org.osiam.mail.from
 
 The sender address from where the emails will be send to the user.
 
-#### org.osiam.mail.*.linkprefix
+## org.osiam.mail.*.linkprefix
 (*changeemail, *lostpassword)
 
 The controller action URL on the client side where the link will point to.
@@ -73,13 +105,13 @@ Here some examples:
  * http://localhost:1234/client/action?
  * http://localhost:1234/client/action?someParameter=value&
 
-#### org.osiam.html.*.url
+## org.osiam.html.*.url
 (*changeemail, *lostpassword)
 
 The controller action URL on the client side where the call arrives, submitted by the HTML from.
 This must be a URL on client side and should not point directly to the osiam registration module due to security issues.
 
-#### org.osiam.mail.server.*
+## org.osiam.mail.server.*
 * *.smtp.port=25 (default)
 * *.host.name=localhost (default)
 * *.username=username (example)
@@ -88,18 +120,30 @@ This must be a URL on client side and should not point directly to the osiam reg
 * *.smtp.auth=false (default)
 * *.transport.protocol=smtp (default)
 
-#### org.osiam.addon-self-administration.client.id
+# Client
+
+The self administration performs background tasks, like cleaning up expired one-time tokens, but
+also foreground operations, like registering a new user. Therefore it needs an own OAuth 2 client
+to authenticate against OSIAM.
+
+## org.osiam.addon-self-administration.client.id
 
 The id of the self administration client that also has to be imported in the
 database.
 
 Default: addon-self-administration-client
 
-#### org.osiam.addon-self-administration.client.secret
+## org.osiam.addon-self-administration.client.secret
 
 The secret of the self administration client, needs to be set!
 
-#### org.osiam.addon-self-administration.registration.activation-token-timeout
+# Tokens
+
+The self administration generates tokens for registration, changing a user's email address and
+resetting a user's password. These tokens have a limited lifespan, that can be configured separately
+for each operation. You can also disable the cleanup of tokens completely.
+
+## org.osiam.addon-self-administration.registration.activation-token-timeout
 
 Specify how long the activation token is valid before the user has to request
 a new one. Also using this property to configure the delay to perform the
@@ -117,7 +161,7 @@ Example: 2d 12h 30m 5s
 
 Default: 24h
 
-#### org.osiam.addon-self-administration.change-email.confirmation-token-timeout
+## org.osiam.addon-self-administration.change-email.confirmation-token-timeout
 
 Specify how long the confirmation token is valid before the user has to request
 a new one. Also using this property to configure the delay to perform the
@@ -135,7 +179,7 @@ Example: 2d 12h 30m 5s
 
 Default: 24h
 
-#### org.osiam.addon-self-administration.lost-password.one-time-password-timeout
+## org.osiam.addon-self-administration.lost-password.one-time-password-timeout
 
 Specify how long the one time password is valid before the user has to request
 a new one. Also using this property to configure the delay to perform the
@@ -153,7 +197,7 @@ Example: 2d 12h 30m 5s
 
 Default: 24h
 
-#### org.osiam.addon-self-administration.one-time-token-scavenger.enabled
+## org.osiam.addon-self-administration.one-time-token-scavenger.enabled
 
 Enable the scavenging of expired one time tokens. Affects all three kinds of
 tokens, i.e. change email, activation after registration, and lost password.

--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
 
     <groupId>org.osiam</groupId>
     <artifactId>addon-self-administration</artifactId>
-    <version>2.0-SNAPSHOT</version>
+    <version>1.7-SNAPSHOT</version>
     <packaging>war</packaging>
 
     <name>OSIAM Self Administration</name>

--- a/pom.xml
+++ b/pom.xml
@@ -84,7 +84,7 @@
         <dependency>
             <groupId>org.osiam</groupId>
             <artifactId>connector4java</artifactId>
-            <version>2.0-SNAPSHOT</version>
+            <version>1.8-SNAPSHOT</version>
         </dependency>
 
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -90,7 +90,7 @@
         <dependency>
             <groupId>org.osiam</groupId>
             <artifactId>addon-self-administration-plugin-api</artifactId>
-            <version>2.0-SNAPSHOT</version>
+            <version>1.5-SNAPSHOT</version>
         </dependency>
 
         <dependency>

--- a/src/main/deploy/addon-self-administration.properties
+++ b/src/main/deploy/addon-self-administration.properties
@@ -31,8 +31,17 @@ org.osiam.html.emailchange.url=http://localhost/
 #org.osiam.mail.server.smtp.starttls.enable=false
 #org.osiam.mail.server.smtp.auth=false
 
-# OSIAM home URL
-#org.osiam.home=http://localhost:8080/osiam
+# OSIAM home URL (OSIAM 3.x)
+#org.osiam.home=
+
+# OSIAM auth server configuration (OSIAM 2.x)
+#org.osiam.auth-server.home=http://localhost:8080/osiam-auth-server
+
+# OSIAM resource server configuration (OSIAM 2.x)
+#org.osiam.resource-server.home=http://localhost:8080/osiam-resource-server
+
+# Enable legacy schemas mode, if you use OSIAM <= 2.3 (resource-server 2.2)
+#org.osiam.connector.legacy-schemas=false
 
 #org.osiam.html.dependencies.bootstrap=http://getbootstrap.com/dist/css/bootstrap.css
 #org.osiam.html.dependencies.angular=http://code.angularjs.org/1.2.0-rc.3/angular.min.js

--- a/src/main/java/org/osiam/addons/self_administration/Config.java
+++ b/src/main/java/org/osiam/addons/self_administration/Config.java
@@ -82,8 +82,17 @@ public class Config extends WebMvcConfigurerAdapter {
     @Value("${org.osiam.html.form.password.length:8}")
     private int passwordLength;
 
-    @Value("${org.osiam.home:http://localhost:8080/osiam}")
+    @Value("${org.osiam.home:}")
     private String osiamHome;
+
+    @Value("${org.osiam.resource-server.home:http://localhost:8080/osiam-resource-server}")
+    private String resourceServerHome;
+
+    @Value("${org.osiam.auth-server.home:http://localhost:8080/osiam-auth-server}")
+    private String authServerHome;
+
+    @Value("${org.osiam.connector.legacy-schemas:false}")
+    private boolean useLegacySchemas;
 
     @Value("${org.osiam.mail.from:selfadmin@localhost}")
     private String fromAddress;
@@ -150,6 +159,18 @@ public class Config extends WebMvcConfigurerAdapter {
 
     public String getOsiamHome() {
         return osiamHome;
+    }
+
+    public String getResourceServerHome() {
+        return resourceServerHome;
+    }
+
+    public String getAuthServerHome() {
+        return authServerHome;
+    }
+
+    public boolean useLegacySchemas() {
+        return useLegacySchemas;
     }
 
     public String getClientId() {

--- a/src/main/java/org/osiam/addons/self_administration/SelfAdministration.java
+++ b/src/main/java/org/osiam/addons/self_administration/SelfAdministration.java
@@ -85,9 +85,17 @@ public class SelfAdministration extends SpringBootServletInitializer {
     @Bean
     public OsiamConnector osiamConnector(Config config) {
         OsiamConnector.Builder oConBuilder = new OsiamConnector.Builder()
-                .withEndpoint(config.getOsiamHome())
                 .setClientId(config.getClientId())
                 .setClientSecret(config.getClientSecret());
+
+        if (!Strings.isNullOrEmpty(config.getOsiamHome())) {
+            oConBuilder.withEndpoint(config.getOsiamHome());
+        } else {
+            oConBuilder.setAuthServerEndpoint(config.getAuthServerHome())
+                    .setResourceServerEndpoint(config.getResourceServerHome())
+                    .withLegacySchemas(config.useLegacySchemas());
+        }
+
         return oConBuilder.build();
     }
 }

--- a/src/main/java/org/osiam/addons/self_administration/SelfAdministration.java
+++ b/src/main/java/org/osiam/addons/self_administration/SelfAdministration.java
@@ -85,7 +85,7 @@ public class SelfAdministration extends SpringBootServletInitializer {
     @Bean
     public OsiamConnector osiamConnector(Config config) {
         OsiamConnector.Builder oConBuilder = new OsiamConnector.Builder()
-                .setEndpoint(config.getOsiamHome())
+                .withEndpoint(config.getOsiamHome())
                 .setClientId(config.getClientId())
                 .setClientSecret(config.getClientSecret());
         return oConBuilder.build();


### PR DESCRIPTION
We only want to maintain a single version of the addon by now, so old
behavior must be restored. This restores the deleted configuration
properties to connect to OSIAM 2.x and adds support for the new legacy
schema mode of the connector.