### PR TITLE
Fix user id in registration mail

### DIFF
--- a/src/main/java/org/osiam/addons/self_administration/registration/RegistrationService.java
+++ b/src/main/java/org/osiam/addons/self_administration/registration/RegistrationService.java
@@ -141,14 +141,14 @@ public class RegistrationService {
     }
 
     public User registerUser(User user, String requestUrl) {
-        User result = saveRegistrationUser(user);
+        User savedUser = saveRegistrationUser(user);
         try {
-            sendRegistrationEmail(user, requestUrl);
-            return result;
+            sendRegistrationEmail(savedUser, requestUrl);
         } catch (Exception e) {
-            osiamService.deleteUser(result.getId());
+            osiamService.deleteUser(savedUser.getId());
             throw new UserNotRegisteredException();
         }
+        return savedUser;
     }
 
     public void postRegistration(User user) throws CallbackException {


### PR DESCRIPTION
The registration mail contained a literal "null" as user id in the
activation link.
The wrong user object had been used to generate the mail.
The right user is the one from the server, because its `id` attribute is
set.