### PR TITLE
Get rid off the plugin example dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -91,9 +91,6 @@
 
         <!-- OSIAM -->
         <version.osiam>3.0-SNAPSHOT</version.osiam>
-        <version.osiam.addon-self-administration-plugin-example>
-            1.4-SNAPSHOT
-        </version.osiam.addon-self-administration-plugin-example>
 
         <sonar.core.codeCoveragePlugin>cobertura</sonar.core.codeCoveragePlugin>
         <sonar.dynamicAnalysis>reuseReports</sonar.dynamicAnalysis>
@@ -437,6 +434,7 @@
                                 <configuration>
                                     <sources>
                                         <source>src/integrationtest/groovy</source>
+                                        <source>src/integrationtest/java</source>
                                     </sources>
                                 </configuration>
                             </execution>
@@ -466,6 +464,26 @@
                     </plugin>
 
                     <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-jar-plugin</artifactId>
+                        <version>2.6</version>
+                        <executions>
+                            <execution>
+                                <phase>package</phase>
+                                <goals>
+                                    <goal>test-jar</goal>
+                                </goals>
+                                <configuration>
+                                    <finalName>addon-self-administration-plugin-example</finalName>
+                                    <includes>
+                                        <include>**/plugin/impl/*</include>
+                                    </includes>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+
+                    <plugin>
                         <artifactId>maven-dependency-plugin</artifactId>
                         <executions>
                             <execution>
@@ -482,25 +500,6 @@
                                             <version>${version.osiam}</version>
                                             <type>war</type>
                                             <destFileName>osiam.war</destFileName>
-                                        </artifactItem>
-                                    </artifactItems>
-                                    <overWriteSnapshots>true</overWriteSnapshots>
-                                </configuration>
-                            </execution>
-                            <execution>
-                                <id>download-addon-self-administration-plugin</id>
-                                <phase>generate-resources</phase>
-                                <goals>
-                                    <goal>copy</goal>
-                                </goals>
-                                <configuration>
-                                    <artifactItems>
-                                        <artifactItem>
-                                            <groupId>org.osiam</groupId>
-                                            <artifactId>addon-self-administration-plugin-example</artifactId>
-                                            <version>${version.osiam.addon-self-administration-plugin-example}</version>
-                                            <type>jar</type>
-                                            <destFileName>addon-self-administration-plugin-example.jar</destFileName>
                                         </artifactItem>
                                     </artifactItems>
                                     <overWriteSnapshots>true</overWriteSnapshots>

--- a/src/integrationtest/docker/tomcat/Dockerfile
+++ b/src/integrationtest/docker/tomcat/Dockerfile
@@ -2,7 +2,7 @@ FROM tomcat:8-jre8
 
 COPY addon-self-administration-${project.version} $CATALINA_HOME/webapps/addon-self-administration
 
-COPY addon-self-administration-plugin-example.jar /install/plugin-example.jar
+COPY addon-self-administration-plugin-example-tests.jar /install/plugin-example.jar
 COPY selfadminexample.properties /install/
 
 COPY osiam.yaml /var/lib/osiam/config/osiam.yaml

--- a/src/integrationtest/docker/tomcat/conf.yml
+++ b/src/integrationtest/docker/tomcat/conf.yml
@@ -1,7 +1,7 @@
 packaging:
   add:
     - target/addon-self-administration-${project.version}
-    - target/dependency/addon-self-administration-plugin-example.jar
+    - target/addon-self-administration-plugin-example-tests.jar
     - target/dependency/osiam.war
 
 links:

--- a/src/integrationtest/java/org/osiam/addons/self_administration/plugin/impl/PluginImpl.java
+++ b/src/integrationtest/java/org/osiam/addons/self_administration/plugin/impl/PluginImpl.java
@@ -1,0 +1,130 @@
+/*
+* Copyright (C) 2015 tarent AG
+*
+* Permission is hereby granted, free of charge, to any person obtaining
+* a copy of this software and associated documentation files (the
+* "Software"), to deal in the Software without restriction, including
+* without limitation the rights to use, copy, modify, merge, publish,
+* distribute, sublicense, and/or sell copies of the Software, and to
+* permit persons to whom the Software is furnished to do so, subject to
+* the following conditions:
+*
+* The above copyright notice and this permission notice shall be
+* included in all copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+package org.osiam.addons.self_administration.plugin.impl;
+
+import org.osiam.addons.self_administration.plugin_api.CallbackException;
+import org.osiam.addons.self_administration.plugin_api.CallbackPlugin;
+import org.osiam.client.OsiamConnector;
+import org.osiam.client.oauth.AccessToken;
+import org.osiam.client.oauth.Scope;
+import org.osiam.client.query.Query;
+import org.osiam.client.query.QueryBuilder;
+import org.osiam.resources.scim.Email;
+import org.osiam.resources.scim.Group;
+import org.osiam.resources.scim.SCIMSearchResult;
+import org.osiam.resources.scim.UpdateGroup;
+import org.osiam.resources.scim.User;
+
+/**
+ * Simple Plugin implementation.
+ */
+public class PluginImpl implements CallbackPlugin {
+
+    private static final String TEST_GROUP_NAME = "Test";
+
+    private OsiamConnector connector;
+    private AccessToken accessToken;
+
+    public void performPreRegistrationActions(User user) throws CallbackException {
+        if (user.getEmails() != null) for (Email email : user.getEmails()) {
+            if (!email.getValue().endsWith(".org")) {
+                throw new CallbackException("The given Email '" + email.getValue() + "' must end with .org!");
+            }
+        }
+    }
+
+    @Override
+    public void performPostRegistrationActions(User user) throws CallbackException {
+        OsiamConnector connector = getOsiamConnector();
+
+        Group testGroup = getTestGroup(connector);
+        UpdateGroup uGroup = new UpdateGroup.Builder().addMember(user.getId()).build();
+
+        connector.updateGroup(testGroup.getId(), uGroup, getAccessToken());
+    }
+
+    private Group getTestGroup(OsiamConnector connector) {
+        Query groupQuery = new QueryBuilder().filter("displayName eq \"" + TEST_GROUP_NAME + "\"").build();
+        SCIMSearchResult<Group> result = connector.searchGroups(groupQuery, getAccessToken());
+
+        if (result.getTotalResults() > 0) {
+            Group testGroup = result.getResources().get(0);
+            return testGroup;
+        }
+
+        return createTestGroup(connector);
+    }
+
+    private Group createTestGroup(OsiamConnector connector) {
+        Group testGroup = new Group.Builder(TEST_GROUP_NAME).build();
+
+        return connector.createGroup(testGroup, getAccessToken());
+    }
+
+    private AccessToken getAccessToken() {
+        if (accessToken == null) {
+            accessToken = getOsiamConnector().retrieveAccessToken(getUserName(), getUserPassword(), Scope.ADMIN);
+        }
+
+        return accessToken;
+    }
+
+    private OsiamConnector getOsiamConnector() {
+        if (connector == null) {
+            OsiamConnector.Builder builder = new OsiamConnector.Builder()
+                    .setClientId(getClientId())
+                    .setClientSecret(getClientSecret());
+
+            builder.withEndpoint(getOsiamEndpoint());
+
+            connector = builder.build();
+        }
+
+        return connector;
+    }
+
+    private String getUserName() {
+        return System.getProperty("osiam.addon-self-administration.plugin.user.name", "admin");
+    }
+
+    private String getUserPassword() {
+        return System.getProperty("osiam.addon-self-administration.plugin.user.password", "koala");
+    }
+
+    private String getOsiamEndpoint() {
+        return System.getProperty("osiam.addon-self-administration.plugin.osiam.endpoint", "http://localhost:8080/osiam");
+    }
+
+    private String getOsiamVersion() {
+        return System.getProperty("osiam.addon-self-administration.plugin.osiam.version", "3");
+    }
+
+    private String getClientId() {
+        return System.getProperty("osiam.addon-self-administration.plugin.osiam.client.id", "example-client");
+    }
+
+    private String getClientSecret() {
+        return System.getProperty("osiam.addon-self-administration.plugin.osiam.client.secret", "secret");
+    }
+}


### PR DESCRIPTION
To test the plugin mechanism for the registration process, an
example implementation was created as dependency. This PR moves
the plugin example to the test code base and creates the jar
within the integration tests preparation.