### PR TITLE
Update connector, debug mode and some minor things Changes:

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,11 +28,27 @@ Run the integration-tests
 
     $ mvn clean verify -P integration-tests
 
+### Run with Debugging
+
+If you want to debug the running Self Administration, then just add the `debug`
+profile when you run Maven:
+
+    $ mvn clean verify -P integration-tests,debug
+
+You can connect to the debugging agent using `localhost:8000`.
+
 ### Run in your IDE
 
 To run the integration-tests in your IDE against the started containers
 
     $ mvn clean pre-integration-test -P integration-tests
+
+If you also want to debug the running Self Administration, add the `debug`
+profile when you run Maven:
+
+    $ mvn clean pre-integration-test -P integration-tests,debug
+
+You can connect to the debugging agent using `localhost:8000`.
 
 If you are on mac or want to run them in a VM, just checkout the
 [OSIAM vagrant VM](https://github.com/osiam/vagrant). It's pretty easy to setup.

--- a/pom.xml
+++ b/pom.xml
@@ -106,7 +106,7 @@
         <dependency>
             <groupId>org.osiam</groupId>
             <artifactId>addon-self-administration-plugin-api</artifactId>
-            <version>1.5</version>
+            <version>1.6-SNAPSHOT</version>
         </dependency>
 
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -84,6 +84,8 @@
 
         <osiam.database.host>${osiam.host}</osiam.database.host>
 
+        <debug.pre.command.tomcat/>
+
         <osiam.mail.host>${osiam.host}</osiam.mail.host>
         <osiam.mail.port>11110</osiam.mail.port>
 
@@ -602,6 +604,14 @@
                 </plugins>
             </build>
         </profile>
+
+        <profile>
+            <id>debug</id>
+            <properties>
+                <debug.pre.command.tomcat>"jpda",</debug.pre.command.tomcat>
+            </properties>
+        </profile>
+
 
         <!-- ==================== Profile: build internally for integration runs ==================== -->
         <!-- Deployment needs to be run from jenkins server which has credentials to access the internal repository -->

--- a/pom.xml
+++ b/pom.xml
@@ -102,7 +102,7 @@
         <dependency>
             <groupId>org.osiam</groupId>
             <artifactId>connector4java</artifactId>
-            <version>1.8</version>
+            <version>1.9-SNAPSHOT</version>
         </dependency>
 
         <dependency>

--- a/src/integrationtest/docker/tomcat/Dockerfile
+++ b/src/integrationtest/docker/tomcat/Dockerfile
@@ -15,10 +15,12 @@ COPY greenmail-webapp-1.4.1 $CATALINA_HOME/webapps/greenmail-webapp
 RUN cat /install/selfadminexample.properties >> $CATALINA_HOME/conf/catalina.properties
 
 RUN sed -i 's/8080/8480/g' $CATALINA_HOME/conf/server.xml
+RUN echo "JPDA_ADDRESS=8000" > $CATALINA_HOME/bin/setenv.sh
 
 RUN cp -p /usr/share/zoneinfo/${user.timezone} /etc/localtime
 RUN echo "${user.timezone}" > /etc/timezone
 
-EXPOSE 8480 11110
+EXPOSE 8480 11110 8000
 
-CMD [ "catalina.sh", "run"]
+CMD [ "catalina.sh", ${debug.pre.command.tomcat} "run"]
+

--- a/src/integrationtest/docker/tomcat/conf.yml
+++ b/src/integrationtest/docker/tomcat/conf.yml
@@ -8,6 +8,7 @@ links:
   - postgres
 
 ports:
+  - 8000
   - 8480
   - 11110
 

--- a/src/integrationtest/resources/osiam.properties
+++ b/src/integrationtest/resources/osiam.properties
@@ -1,5 +1,5 @@
 org.osiam.db.driver=org.postgresql.Driver
-org.osiam.db.url=jdbc:postgresql://${osiam.host}:45432/osiam
+org.osiam.db.url=jdbc:postgresql://${osiam.host:localhost}:45432/osiam
 org.osiam.db.username=osiam
 org.osiam.db.password=osiam
 org.osiam.db.dialect=org.hibernate.dialect.PostgresPlusDialect

--- a/src/main/java/org/osiam/addons/self_administration/controller/ChangeEmailController.java
+++ b/src/main/java/org/osiam/addons/self_administration/controller/ChangeEmailController.java
@@ -169,7 +169,7 @@ public class ChangeEmailController {
      */
     private User getUpdatedUserForEmailChange(String token, String newEmail, OneTimeToken confirmationToken) {
         final AccessToken accessToken = new AccessToken.Builder(token).build();
-        final BasicUser user = osiamConnector.getCurrentUserBasic(accessToken);
+        final User user = osiamConnector.getMe(accessToken);
 
         final Extension extension = new Extension.Builder(Config.EXTENSION_URN)
                 .setField(Config.CONFIRMATION_TOKEN_FIELD, confirmationToken.toString())

--- a/src/main/java/org/osiam/addons/self_administration/controller/LostPasswordController.java
+++ b/src/main/java/org/osiam/addons/self_administration/controller/LostPasswordController.java
@@ -243,7 +243,7 @@ public class LostPasswordController {
 
             User user;
             if (Strings.isNullOrEmpty(userId)) {
-                user = osiamConnector.getCurrentUser(accessToken);
+                user = osiamConnector.getMe(accessToken);
             } else {
                 user = osiamConnector.getUser(userId, accessToken);
             }

--- a/src/test/groovy/org/osiam/addons/self_administration/controller/ChangeEmailControllerSpec.groovy
+++ b/src/test/groovy/org/osiam/addons/self_administration/controller/ChangeEmailControllerSpec.groovy
@@ -80,14 +80,13 @@ class ChangeEmailControllerSpec extends Specification {
         given:
         def authZHeader = 'Bearer ACCESSTOKEN'
         def newEmailValue = 'bam@boom.com'
-        BasicUser basicUser = new BasicUser()
         User user = new User.Builder().build()
 
         when:
         changeEmailController.change(authZHeader, newEmailValue)
 
         then:
-        1 * osiamConnector.getCurrentUserBasic(_) >> basicUser
+        1 * osiamConnector.getMe(_) >> new User.Builder('irrelevant').build()
         1 * osiamConnector.updateUser(_, _, _) >> user
         1 * emailTemplateRendererService.renderEmailSubject(_, _, _) >> 'subject'
         1 * emailTemplateRendererService.renderEmailBody(_, _, _) >> { throw new OsiamException() }
@@ -97,14 +96,13 @@ class ChangeEmailControllerSpec extends Specification {
         given:
         def authZHeader = 'Bearer ACCESSTOKEN'
         def newEmailValue = 'bam@boom.com'
-        BasicUser basicUser = new BasicUser()
         User user = new User.Builder().build()
 
         when:
         changeEmailController.change(authZHeader, newEmailValue)
 
         then:
-        1 * osiamConnector.getCurrentUserBasic(_) >> basicUser
+        1 * osiamConnector.getMe(_) >> new User.Builder('irrelevant').build()
         1 * osiamConnector.updateUser(_, _, _) >> user
         1 * emailTemplateRendererService.renderEmailSubject(_, _, _) >> 'subject'
         1 * emailTemplateRendererService.renderEmailBody(_, _, _) >> { throw new OsiamException() }
@@ -114,14 +112,13 @@ class ChangeEmailControllerSpec extends Specification {
         given:
         def authZHeader = 'Bearer ACCESSTOKEN'
         def newEmailValue = 'bam@boom.com'
-        BasicUser basicUser = new BasicUser()
         User user = new User.Builder().build()
 
         when:
         changeEmailController.change(authZHeader, newEmailValue)
 
         then:
-        1 * osiamConnector.getCurrentUserBasic(_) >> basicUser
+        1 * osiamConnector.getMe(_) >> new User.Builder('irrelevant').build()
         1 * osiamConnector.updateUser(_, _, _) >> user
         1 * emailTemplateRendererService.renderEmailSubject(_, _, _) >> { throw new OsiamException() }
     }
@@ -130,8 +127,7 @@ class ChangeEmailControllerSpec extends Specification {
         given:
         def authZHeader = 'Bearer ACCESSTOKEN'
         def newEmailValue = 'bam@boom.com'
-        BasicUser basicUser = new BasicUser()
-        User user = new User.Builder().build()
+        User user = new User.Builder('irrelevant').build()
 
         def emailContent = 'nine bytes and one placeholder $EMAILCHANGEURL and $BOOTSTRAP and $ANGULAR and $JQUERY'
 
@@ -139,7 +135,7 @@ class ChangeEmailControllerSpec extends Specification {
         def result = changeEmailController.change(authZHeader, newEmailValue)
 
         then:
-        1 * osiamConnector.getCurrentUserBasic(_) >> basicUser
+        1 * osiamConnector.getMe(_) >> new User.Builder('irrelevant').build()
         1 * osiamConnector.updateUser(_, _, _) >> user
         1 * emailTemplateRendererService.renderEmailSubject(_, _, _) >> 'subject'
         1 * emailTemplateRendererService.renderEmailBody(_, _, _) >> emailContent
@@ -156,7 +152,7 @@ class ChangeEmailControllerSpec extends Specification {
         def result = changeEmailController.change(authZ, 'some@email.de')
 
         then:
-        1 * osiamConnector.getCurrentUserBasic(accessToken) >> { throw new UnauthorizedException('unauthorized') }
+        1 * osiamConnector.getMe(accessToken) >> { throw new UnauthorizedException('unauthorized') }
         result.getBody() == '{\"error\":\"unauthorized\"}'
     }
 

--- a/src/test/groovy/org/osiam/addons/self_administration/controller/LostPasswordControllerSpec.groovy
+++ b/src/test/groovy/org/osiam/addons/self_administration/controller/LostPasswordControllerSpec.groovy
@@ -217,7 +217,7 @@ class LostPasswordControllerSpec extends Specification {
 
         then:
         1 * osiamConnector.updateUser(_, _, _) >> user
-        1 * osiamConnector.getCurrentUser(_) >> user
+        1 * osiamConnector.getMe(_) >> user
 
         result.getStatusCode() == HttpStatus.OK
         result.getBody() != null
@@ -249,7 +249,7 @@ class LostPasswordControllerSpec extends Specification {
         def result = lostPasswordController.changePasswordByUser(authZHeader, otp, newPassword)
 
         then:
-        1 * osiamConnector.getCurrentUser(_) >> { throw new OsiamRequestException(409, '') }
+        1 * osiamConnector.getMe(_) >> { throw new OsiamRequestException(409, '') }
 
         result.getStatusCode() == HttpStatus.CONFLICT
     }
@@ -293,7 +293,7 @@ class LostPasswordControllerSpec extends Specification {
         def result = lostPasswordController.changePasswordByUser(authZHeader, otp, newPassword)
 
         then:
-        1 * osiamConnector.getCurrentUser(_) >> user
+        1 * osiamConnector.getMe(_) >> user
         result.getStatusCode() == HttpStatus.FORBIDDEN
     }
 
@@ -338,7 +338,7 @@ class LostPasswordControllerSpec extends Specification {
         def result = lostPasswordController.changePasswordByUser(authZHeader, otp, newPassword)
 
         then:
-        1 * osiamConnector.getCurrentUser(_) >> user
+        1 * osiamConnector.getMe(_) >> user
         1 * osiamConnector.updateUser(_, _, _) >> { throw new OsiamRequestException(400, '') }
         result.getStatusCode() == HttpStatus.BAD_REQUEST
         result.getBody() != null
@@ -393,7 +393,7 @@ class LostPasswordControllerSpec extends Specification {
         def result = lostPasswordController.changePasswordByUser(authZHeader, otp, newPassword)
 
         then:
-        1 * osiamConnector.getCurrentUser(_) >> user
+        1 * osiamConnector.getMe(_) >> user
         result.getStatusCode() == HttpStatus.FORBIDDEN
     }
 }


### PR DESCRIPTION
- Update connector4java to 1.9-SNAPSHOT

    OSIAM 3.0 introduced a new `/Me` endpoint. Adjust all usages of the former
    endpoint to use the new one.

- Add support for debugging during the integration tests
- Update plugin API to 1.6-SNAPSHOT
- Set default database URL to localhost

    Otherwise it is not possible to start the ITs from the IDE.