### PR TITLE
Fix tests that are based on a bug in the connector

### DIFF
--- a/src/test/groovy/org/osiam/addons/self_administration/registration/RegistrationServiceSpec.groovy
+++ b/src/test/groovy/org/osiam/addons/self_administration/registration/RegistrationServiceSpec.groovy
@@ -60,7 +60,7 @@ class RegistrationServiceSpec extends Specification {
 
         then:
         resultUser != null
-        1 * osiamService.createUser(user) >> user
+        1 * osiamService.createUser(_) >> { User registrationUser -> registrationUser }
         1 * renderAndSendEmail.renderAndSendEmail(_, _, _, _, _)
     }
 
@@ -82,7 +82,7 @@ class RegistrationServiceSpec extends Specification {
 
         then:
         thrown(UserNotRegisteredException)
-        1 * osiamService.createUser(user) >> user
+        1 * osiamService.createUser(_) >> { User registrationUser -> registrationUser }
         1 * renderAndSendEmail.renderAndSendEmail(_, _, _, _, _) >> { throw new MailSendException("") }
         1 * osiamService.deleteUser(_)
     }


### PR DESCRIPTION
Both tests make use of the fact, that a `User` was not immutable and
could be changed via a copy-of builder. Letting the `OsiamService` Mock
just return its argument is also more aligned with the reality of the
workings of the class.