### PR TITLE
Publish latest snapshot to Bintray

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,9 @@ Learn how to install and configure this add-on for production in the
 ## Snapshots
 
 To use the latest snapshot of the OSIAM self-administration just download it
-from the oss jfrog repository:
-https://oss.jfrog.org/artifactory/repo/org/osiam/addon-self-administration
+from Bintray:
+https://dl.bintray.com/osiam/downloads/addon-self-administration/latest/addon-self-administration-latest.war
+([GPG Signature](https://dl.bintray.com/osiam/downloads/addon-self-administration/latest/addon-self-administration-latest.war.asc))
 
 ## Run the integration-tests
 

--- a/circle.yml
+++ b/circle.yml
@@ -29,8 +29,7 @@ deployment:
   staging:
     branch: master
     commands:
-      - wget https://raw.githubusercontent.com/osiam/circleci/master/settings.xml
-      - mvn deploy -s settings.xml -DskipTests
+      - curl -T target/addon-self-administration.war -u${BINTRAY_USER}:${BINTRAY_KEY} -H "X-Bintray-Package:addon-self-administration" -H "X-Bintray-Version:latest" -H "X-Bintray-Publish:1" -H "X-Bintray-Override:1" https://api.bintray.com/content/osiam/downloads/addon-self-administration/latest/addon-self-administration-latest.war
       - >
         curl -H "Content-Type: application/json" --data '{"source_type": "Branch", "source_name": "master"}' -X POST https://registry.hub.docker.com/u/osiamorg/osiam/trigger/${DOCKER_HUB_TRIGGER_TOKEN}/
       - >

--- a/pom.xml
+++ b/pom.xml
@@ -68,14 +68,6 @@
         <tag>HEAD</tag>
     </scm>
 
-    <distributionManagement>
-        <snapshotRepository>
-            <id>snapshots</id>
-            <name>oss-jfrog-artifactory-snapshots</name>
-            <url>https://oss.jfrog.org/artifactory/oss-snapshot-local</url>
-        </snapshotRepository>
-    </distributionManagement>
-
     <properties>
         <start-class>org.osiam.addons.self_administration.SelfAdministration</start-class>
 
@@ -273,7 +265,7 @@
             </snapshots>
         </repository>
         <repository>
-            <snapshots />
+            <snapshots/>
             <id>osiam-snapshots</id>
             <name>libs-snapshot</name>
             <url>http://oss.jfrog.org/artifactory/libs-snapshot</url>
@@ -376,15 +368,6 @@
                         </goals>
                     </execution>
                 </executions>
-            </plugin>
-
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-release-plugin</artifactId>
-                <version>2.5.3</version>
-                <configuration>
-                    <tagNameFormat>v@{project.version}</tagNameFormat>
-                </configuration>
             </plugin>
 
             <plugin>
@@ -624,56 +607,6 @@
             <properties>
                 <debug.pre.command.tomcat>"jpda",</debug.pre.command.tomcat>
             </properties>
-        </profile>
-
-
-        <!-- ==================== Profile: build internally for integration runs ==================== -->
-        <!-- Deployment needs to be run from jenkins server which has credentials to access the internal repository -->
-        <profile>
-            <id>integration</id>
-            <distributionManagement>
-                <repository>
-                    <id>osiam-repository</id>
-                    <name>public evolvis release repository</name>
-                    <url>scpexe://maven-repo.evolvis.org:/var/www/maven_repo/releases</url>
-                </repository>
-                <snapshotRepository>
-                    <id>OSIAM-NG-SNAPSHOT-repository</id>
-                    <name>public evolvis release repository</name>
-                    <url>scpexe://maven-repo.evolvis.org:/var/www/maven_repo/snapshots/</url>
-                </snapshotRepository>
-            </distributionManagement>
-            <repositories>
-                <repository>
-                    <id>osiam releases repo</id>
-                    <url>https://maven-repo.evolvis.org/releases</url>
-                </repository>
-            </repositories>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-deploy-plugin</artifactId>
-                        <version>2.8.2</version>
-                        <dependencies>
-                            <dependency>
-                                <groupId>org.apache.maven.wagon</groupId>
-                                <artifactId>wagon-ssh-external</artifactId>
-                                <version>2.6</version>
-                            </dependency>
-                        </dependencies>
-                        <executions>
-                            <execution>
-                                <id>default-deploy</id>
-                                <phase>deploy</phase>
-                                <goals>
-                                    <goal>deploy</goal>
-                                </goals>
-                            </execution>
-                        </executions>
-                    </plugin>
-                </plugins>
-            </build>
         </profile>
 
         <profile>


### PR DESCRIPTION
This commit changes that only one snapshot artifact is available
on Bintray and remove the deployment to the oss jfrog snapshot
maven repo. This artifact does not need to be available as maven
dependency and also not the future releases, so this commit removes
the maven release plugin and the maven profile 'integration'.