### PR TITLE
Deploy WAR file to a Maven repo

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -31,6 +31,8 @@ deployment:
   staging:
     branch: master
     commands:
+      - wget https://raw.githubusercontent.com/osiam/circleci/master/settings.xml
+      - mvn deploy -s settings.xml -DskipTests
       - curl -T target/addon-self-administration.war -u${BINTRAY_USER}:${BINTRAY_KEY} -H "X-Bintray-Package:addon-self-administration" -H "X-Bintray-Version:latest" -H "X-Bintray-Publish:1" -H "X-Bintray-Override:1" https://api.bintray.com/content/osiam/downloads/addon-self-administration/latest/addon-self-administration-latest.war
       - >
         curl -H "Content-Type: application/json" --data '{"source_type": "Branch", "source_name": "master"}' -X POST https://registry.hub.docker.com/u/osiamorg/osiam/trigger/${DOCKER_HUB_TRIGGER_TOKEN}/
@@ -40,4 +42,6 @@ deployment:
     tag: /.*/
     owner: osiam
     commands:
+      - wget https://raw.githubusercontent.com/osiam/circleci/master/settings.xml
+      - mvn deploy -s settings.xml -DskipTests
       - curl -T target/addon-self-administration.war -u${BINTRAY_USER}:${BINTRAY_KEY} -H "X-Bintray-Package:addon-self-administration" -H "X-Bintray-Version:${CIRCLE_TAG}" -H "X-Bintray-Publish:1" -H "X-Bintray-Override:1" https://api.bintray.com/content/osiam/downloads/addon-self-administration/${CIRCLE_TAG}/addon-self-administration-${CIRCLE_TAG}.war

--- a/pom.xml
+++ b/pom.xml
@@ -68,6 +68,19 @@
         <tag>HEAD</tag>
     </scm>
 
+    <distributionManagement>
+        <repository>
+            <id>releases</id>
+            <name>osiam-releases</name>
+            <url>https://api.bintray.com/maven/osiam/OSIAM/org.osiam:osiam/;publish=1</url>
+        </repository>
+        <snapshotRepository>
+            <id>snapshots</id>
+            <name>osiam-snapshots</name>
+            <url>https://oss.jfrog.org/artifactory/oss-snapshot-local</url>
+        </snapshotRepository>
+    </distributionManagement>
+
     <properties>
         <start-class>org.osiam.addons.self_administration.SelfAdministration</start-class>
 


### PR DESCRIPTION
This is needed for the 2.x ITs, that still use the self-admin to run
some tests against it.