### PR TITLE
Remove Evolvis releases repo

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -11,7 +11,7 @@ If you find this file in the distribution of the OSIAM addon, please jump
 to the installation instructions among
 
 if not, just download the .zip or .tar.gz distribution file here:
-https://maven-repo.evolvis.org/releases/org/osiam/addon-self-administration/
+https://dl.bintray.com/osiam/downloads/addon-self-administration/
 
 or you can run the following commands on your console:
 $ git clone https://github.com/osiam/addon-self-administration.git

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -14,13 +14,13 @@ installed the latest release version of [OSIAM]
 We recommend to choose the latest OSIAM addon-self-administration release
 version:
 
- * Release Repository: http://maven-repo.evolvis.org/releases/org/osiam/addon-self-administration
+ * Release Repository: https://dl.bintray.com/osiam/downloads/addon-self-administration/
  * GitHub Release Tags: https://github.com/osiam/addon-self-administration/releases
 
 The setup of the addon-self-administration is really easy with the distribution
 .zip or .tar.gz, which you can find here:
 
-    http://maven-repo.evolvis.org/releases/org/osiam/addon-self-administration/<VERSION>/addon-self-administration-<VERSION>.zip or .tar.gz
+    https://dl.bintray.com/osiam/downloads/addon-self-administration/<VERSION>/addon-self-administration-<VERSION>-distribution.zip or .tar.gz
 
 Unpack the distribution and copy the war file to you application server (e.g.
 Tomcat). All files and folders inside the /configuration folder have to copy to

--- a/pom.xml
+++ b/pom.xml
@@ -271,13 +271,6 @@
 
     <repositories>
         <repository>
-            <id>osiam-releases</id>
-            <url>https://maven-repo.evolvis.org/releases</url>
-            <snapshots>
-                <enabled>false</enabled>
-            </snapshots>
-        </repository>
-        <repository>
             <snapshots/>
             <id>osiam-snapshots</id>
             <name>libs-snapshot</name>


### PR DESCRIPTION
AFAIK, there are no releases on the Evolvis releases repo, that we
wouldn't get from the central too.