### PR TITLE
Bump dependencies and plugins

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -352,7 +352,7 @@
                 <artifactId>maven-deploy-plugin</artifactId>
                 <version>2.8.2</version>
                 <configuration>
-                    <file>${build.directory}/${project.artifactId}.war</file>
+                    <file>${project.build.directory}/${project.artifactId}.war</file>
                     <pomFile>pom.xml</pomFile>
                 </configuration>
             </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -189,7 +189,7 @@
         <dependency>
             <groupId>org.objenesis</groupId>
             <artifactId>objenesis</artifactId>
-            <version>2.3</version>
+            <version>2.4</version>
             <scope>test</scope>
         </dependency>
 
@@ -203,14 +203,14 @@
         <dependency>
             <groupId>com.github.springtestdbunit</groupId>
             <artifactId>spring-test-dbunit</artifactId>
-            <version>1.2.1</version>
+            <version>1.3.0</version>
             <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>org.dbunit</groupId>
             <artifactId>dbunit</artifactId>
-            <version>2.4.9</version>
+            <version>2.5.2</version>
             <scope>test</scope>
         </dependency>
 
@@ -237,14 +237,14 @@
         <dependency>
             <groupId>org.glassfish.jersey.core</groupId>
             <artifactId>jersey-client</artifactId>
-            <version>2.22.2</version>
+            <version>2.23.1</version>
             <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>org.glassfish.jersey.media</groupId>
             <artifactId>jersey-media-json-jackson</artifactId>
-            <version>2.22.2</version>
+            <version>2.23.1</version>
             <scope>test</scope>
         </dependency>
 
@@ -385,7 +385,7 @@
             <plugin>
                 <groupId>org.eluder.coveralls</groupId>
                 <artifactId>coveralls-maven-plugin</artifactId>
-                <version>4.1.0</version>
+                <version>4.2.0</version>
                 <configuration>
                     <jacocoReports>
                         <entry>${project.build.directory}/coverage-reports/jacoco/jacoco.xml</entry>
@@ -463,7 +463,7 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-jar-plugin</artifactId>
-                        <version>2.6</version>
+                        <version>3.0.0</version>
                         <executions>
                             <execution>
                                 <phase>package</phase>
@@ -507,7 +507,7 @@
 
                     <plugin>
                         <artifactId>maven-resources-plugin</artifactId>
-                        <version>2.7</version>
+                        <version>3.0.0</version>
                         <configuration>
                             <includeEmptyDirs>true</includeEmptyDirs>
                             <encoding>UTF-8</encoding>


### PR DESCRIPTION
Also use `project.build.directory` instead of `build.directory`, because it is deprecated.