### PR TITLE
Only consume snapshots from OSS JFrog

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -259,6 +259,9 @@
     <repositories>
         <repository>
             <snapshots/>
+            <releases>
+                <enabled>false</enabled>
+            </releases>
             <id>osiam-snapshots</id>
             <name>libs-snapshot</name>
             <url>http://oss.jfrog.org/artifactory/libs-snapshot</url>


### PR DESCRIPTION
Previously, also releases would be consumed from it.