### PR TITLE
Downgrade http-builder test dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -224,7 +224,7 @@
         <dependency>
             <groupId>org.codehaus.groovy.modules.http-builder</groupId>
             <artifactId>http-builder</artifactId>
-            <version>0.7.2</version>
+            <version>0.7.1</version>
             <scope>test</scope>
             <exclusions>
                 <exclusion>


### PR DESCRIPTION
Version 0.7.2 vanished from the Central.