### PR TITLE
Change connector and plug-in API version to 'latest-SNAPSHOT'

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -102,13 +102,13 @@
         <dependency>
             <groupId>org.osiam</groupId>
             <artifactId>connector4java</artifactId>
-            <version>1.9.CR1</version>
+            <version>latest-SNAPSHOT</version>
         </dependency>
 
         <dependency>
             <groupId>org.osiam</groupId>
             <artifactId>addon-self-administration-plugin-api</artifactId>
-            <version>1.6.CR1</version>
+            <version>latest-SNAPSHOT</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
This is to support the new versioning scheme for snapshots of the
connector and the plug-in API.

Depends on https://github.com/osiam/connector4java/pull/226 and https://github.com/osiam/addon-self-administration-plugin-api/pull/31